### PR TITLE
add `cargo review-deps current`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -88,10 +88,21 @@ impl Diff {
     }
 }
 
+#[derive(Debug)]
+pub struct Current {
+    pub dest: Option<PathBuf>,
+}
+
+impl Current {
+    pub fn run(self) -> Result<()> {
+        Ok(())
+    }
+}
+
 fn has_diff_cmd() -> bool {
     match Command::new("diff").arg("--version").status() {
         Err(_) => false,
-        Ok(status) => status.success()
+        Ok(status) => status.success(),
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -91,16 +91,14 @@ fn exec_diff(matches: &ArgMatches) -> Result<()> {
     let first = value_of_pkg_id(&matches, "FIRST_PACKAGE_ID")?;
     let second = value_of_pkg_id(&matches, "SECOND_PACKAGE_ID")?;
     let dest = matches.value_of("destination").map(PathBuf::from);
-    let cmd = Diff {
+    Diff {
         first,
         second,
         dest,
-    };
-    cmd.run()
+    }.run()
 }
 
 fn exec_current(matches: &ArgMatches) -> Result<()> {
-    let dest = matches.value_of("destination").map(PathBuf::from);
-    let cmd = Current { dest };
-    cmd.run()
+    let dest = matches.value_of("destination").unwrap().into();
+    Current { dest }.run()
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,7 +3,7 @@ extern crate clap;
 
 use std::path::PathBuf;
 
-use cargo_review_deps::{Diff, PackageId, Result};
+use cargo_review_deps::{Current, Diff, PackageId, Result};
 use clap::{App, AppSettings, Arg, ArgMatches, SubCommand};
 
 fn main() {
@@ -47,6 +47,19 @@ fn main_inner() -> i32 {
                                 .value_name("DIR")
                                 .help("Checkout sources of the two versions to the specified directory")
                         ),
+                )
+                .subcommand(
+                    SubCommand::with_name("current")
+                        .about("Download source code of all of the dependencies to the specified directory")
+                        .arg(
+                            Arg::with_name("destination")
+                                .short("d")
+                                .long("destination")
+                                .takes_value(true)
+                                .value_name("DIR")
+                                .required(true)
+                                .help("Checkout sources of the two versions to the specified directory")
+                        ),
                 ),
         ).get_matches();
 
@@ -58,6 +71,7 @@ fn main_inner() -> i32 {
 
     let res = match cmd {
         "diff" => exec_diff(&matches),
+        "current" => exec_current(&matches),
         _ => unreachable!("no such cmd: {:?}", cmd),
     };
 
@@ -77,10 +91,16 @@ fn exec_diff(matches: &ArgMatches) -> Result<()> {
     let first = value_of_pkg_id(&matches, "FIRST_PACKAGE_ID")?;
     let second = value_of_pkg_id(&matches, "SECOND_PACKAGE_ID")?;
     let dest = matches.value_of("destination").map(PathBuf::from);
-    let diff = Diff {
+    let cmd = Diff {
         first,
         second,
         dest,
     };
-    diff.run()
+    cmd.run()
+}
+
+fn exec_current(matches: &ArgMatches) -> Result<()> {
+    let dest = matches.value_of("destination").map(PathBuf::from);
+    let cmd = Current { dest };
+    cmd.run()
 }

--- a/tests/test_cli.rs
+++ b/tests/test_cli.rs
@@ -1,7 +1,7 @@
 extern crate assert_cli;
 extern crate tempdir;
 
-use std::{fs, env, path::PathBuf};
+use std::{env, fs, path::PathBuf};
 
 use assert_cli::Assert;
 
@@ -50,7 +50,9 @@ fn current_reports_deps() -> std::io::Result<()> {
     let project_dir = tempdir::TempDir::new("temp-project")?;
     let dest = project_dir.path().join("dest");
 
-    fs::write(project_dir.path().join("Cargo.toml"), r#"
+    fs::write(
+        project_dir.path().join("Cargo.toml"),
+        r#"
         [package]
         name = "test"
         version = "0.0.0"
@@ -60,7 +62,8 @@ fn current_reports_deps() -> std::io::Result<()> {
 
         [lib]
         path = "./Cargo.toml"
-    "#)?;
+    "#,
+    )?;
     cmd_current()
         .current_dir(project_dir.path())
         .with_args(&["--destination"])

--- a/tests/test_cli.rs
+++ b/tests/test_cli.rs
@@ -1,7 +1,7 @@
 extern crate assert_cli;
 extern crate tempdir;
 
-use std::{env, path::PathBuf};
+use std::{fs, env, path::PathBuf};
 
 use assert_cli::Assert;
 
@@ -47,10 +47,24 @@ fn diff_copies_sources_to_dest() {
 
 #[test]
 fn current_reports_deps() -> std::io::Result<()> {
-    let dir = tempdir::TempDir::new("diff-tests").unwrap();
+    let project_dir = tempdir::TempDir::new("temp-project")?;
+    let dest = project_dir.path().join("dest");
+
+    fs::write(project_dir.path().join("Cargo.toml"), r#"
+        [package]
+        name = "test"
+        version = "0.0.0"
+
+        [dependencies]
+        thread_local = "=0.3.6"
+
+        [lib]
+        path = "./Cargo.toml"
+    "#)?;
     cmd_current()
+        .current_dir(project_dir.path())
         .with_args(&["--destination"])
-        .with_args(&[&dir.path()])
+        .with_args(&[&dest.as_path()])
         .unwrap();
     Ok(())
 }

--- a/tests/test_cli.rs
+++ b/tests/test_cli.rs
@@ -54,7 +54,7 @@ fn current_reports_deps() -> std::io::Result<()> {
         project_dir.path().join("Cargo.toml"),
         r#"
         [package]
-        name = "test"
+        name = "test-pkg"
         version = "0.0.0"
 
         [dependencies]
@@ -68,7 +68,10 @@ fn current_reports_deps() -> std::io::Result<()> {
         .current_dir(project_dir.path())
         .with_args(&["--destination"])
         .with_args(&[&dest.as_path()])
+        .stderr()
+        .contains("Skipping package `test-pkg`")
         .unwrap();
+    assert!(dest.join("thread_local:0.3.6").exists());
     Ok(())
 }
 

--- a/tests/test_cli.rs
+++ b/tests/test_cli.rs
@@ -5,28 +5,6 @@ use std::{env, path::PathBuf};
 
 use assert_cli::Assert;
 
-// Adapted from
-// https://github.com/rust-lang/cargo/blob/485670b3983b52289a2f353d589c57fae2f60f82/tests/testsuite/support/mod.rs#L507
-fn target_dir() -> PathBuf {
-    env::current_exe()
-        .ok()
-        .map(|mut path| {
-            path.pop();
-            if path.ends_with("deps") {
-                path.pop();
-            }
-            path
-        }).unwrap()
-}
-
-fn cargo_review_deps_exe() -> PathBuf {
-    target_dir().join(format!("cargo-review-deps{}", env::consts::EXE_SUFFIX))
-}
-
-fn base_cmd() -> Assert {
-    Assert::command(&[&cargo_review_deps_exe()]).with_args(&["review-deps"])
-}
-
 fn cmd_diff() -> Assert {
     base_cmd().with_args(&["diff"])
 }
@@ -75,4 +53,26 @@ fn current_reports_deps() -> std::io::Result<()> {
         .with_args(&[&dir.path()])
         .unwrap();
     Ok(())
+}
+
+// Adapted from
+// https://github.com/rust-lang/cargo/blob/485670b3983b52289a2f353d589c57fae2f60f82/tests/testsuite/support/mod.rs#L507
+fn target_dir() -> PathBuf {
+    env::current_exe()
+        .ok()
+        .map(|mut path| {
+            path.pop();
+            if path.ends_with("deps") {
+                path.pop();
+            }
+            path
+        }).unwrap()
+}
+
+fn cargo_review_deps_exe() -> PathBuf {
+    target_dir().join(format!("cargo-review-deps{}", env::consts::EXE_SUFFIX))
+}
+
+fn base_cmd() -> Assert {
+    Assert::command(&[&cargo_review_deps_exe()]).with_args(&["review-deps"])
 }

--- a/tests/test_cli.rs
+++ b/tests/test_cli.rs
@@ -1,14 +1,38 @@
 extern crate assert_cli;
 extern crate tempdir;
 
+use std::{env, path::PathBuf};
+
 use assert_cli::Assert;
 
+// Adapted from
+// https://github.com/rust-lang/cargo/blob/485670b3983b52289a2f353d589c57fae2f60f82/tests/testsuite/support/mod.rs#L507
+fn target_dir() -> PathBuf {
+    env::current_exe()
+        .ok()
+        .map(|mut path| {
+            path.pop();
+            if path.ends_with("deps") {
+                path.pop();
+            }
+            path
+        }).unwrap()
+}
+
+fn cargo_review_deps_exe() -> PathBuf {
+    target_dir().join(format!("cargo-review-deps{}", env::consts::EXE_SUFFIX))
+}
+
+fn base_cmd() -> Assert {
+    Assert::command(&[&cargo_review_deps_exe()]).with_args(&["review-deps"])
+}
+
 fn cmd_diff() -> Assert {
-    Assert::main_binary().with_args(&["review-deps", "diff"])
+    base_cmd().with_args(&["diff"])
 }
 
 fn cmd_current() -> Assert {
-    Assert::main_binary().with_args(&["review-deps", "current"])
+    base_cmd().with_args(&["current"])
 }
 
 #[test]

--- a/tests/test_cli.rs
+++ b/tests/test_cli.rs
@@ -7,6 +7,10 @@ fn cmd_diff() -> Assert {
     Assert::main_binary().with_args(&["review-deps", "diff"])
 }
 
+fn cmd_current() -> Assert {
+    Assert::main_binary().with_args(&["review-deps", "current"])
+}
+
 #[test]
 fn diff_shows_diff() {
     cmd_diff()
@@ -32,8 +36,19 @@ fn diff_copies_sources_to_dest() {
     cmd_diff()
         .with_args(&["rand:0.6.0", "rand:0.6.1", "--destination"])
         .with_args(&[dir.path()])
-        .stdout().is("")
+        .stdout()
+        .is("")
         .unwrap();
     assert!(dir.path().join("rand:0.6.0").exists());
     assert!(dir.path().join("rand:0.6.1").exists());
+}
+
+#[test]
+fn current_reports_deps() -> std::io::Result<()> {
+    let dir = tempdir::TempDir::new("diff-tests").unwrap();
+    cmd_current()
+        .with_args(&["--destination"])
+        .with_args(&[&dir.path()])
+        .unwrap();
+    Ok(())
 }


### PR DESCRIPTION
Here's how this looks like for this crate:

<details>

```~/projects/cargo-review-deps current
λ ./target/debug/cargo-review-deps review-deps current -d deps
Skipping package `cargo-review-deps`: not a crates.io dependency

~/projects/cargo-review-deps current*
λ ls deps
drwxr-xr-x - matklad  4 Dec 15:59 ansi_term:0.11.0
drwxr-xr-x - matklad  4 Dec 15:59 assert_cli:0.6.3
drwxr-xr-x - matklad  4 Dec 15:59 atty:0.2.11
drwxr-xr-x - matklad  4 Dec 15:59 backtrace-sys:0.1.24
drwxr-xr-x - matklad  4 Dec 15:59 backtrace:0.3.9
drwxr-xr-x - matklad  4 Dec 15:59 bitflags:1.0.4
drwxr-xr-x - matklad  4 Dec 15:59 cargo_metadata:0.6.2
drwxr-xr-x - matklad  4 Dec 15:59 cc:1.0.25
drwxr-xr-x - matklad  4 Dec 15:59 cfg-if:0.1.6
drwxr-xr-x - matklad  4 Dec 15:59 clap:2.32.0
drwxr-xr-x - matklad  4 Dec 15:59 colored:1.6.1
drwxr-xr-x - matklad  4 Dec 15:59 copy_dir:0.1.2
drwxr-xr-x - matklad  4 Dec 15:59 difference:2.0.0
drwxr-xr-x - matklad  4 Dec 15:59 environment:0.1.1
drwxr-xr-x - matklad  4 Dec 15:59 error-chain:0.12.0
drwxr-xr-x - matklad  4 Dec 15:59 failure:0.1.3
drwxr-xr-x - matklad  4 Dec 15:59 failure_derive:0.1.3
drwxr-xr-x - matklad  4 Dec 15:59 fuchsia-zircon-sys:0.3.3
drwxr-xr-x - matklad  4 Dec 15:59 fuchsia-zircon:0.3.3
drwxr-xr-x - matklad  4 Dec 15:59 itoa:0.4.3
drwxr-xr-x - matklad  4 Dec 15:59 kernel32-sys:0.2.2
drwxr-xr-x - matklad  4 Dec 15:59 lazy_static:1.2.0
drwxr-xr-x - matklad  4 Dec 15:59 libc:0.2.44
drwxr-xr-x - matklad  4 Dec 15:59 proc-macro2:0.4.24
drwxr-xr-x - matklad  4 Dec 15:59 quote:0.6.10
drwxr-xr-x - matklad  4 Dec 15:59 rand:0.4.3
drwxr-xr-x - matklad  4 Dec 15:59 redox_syscall:0.1.43
drwxr-xr-x - matklad  4 Dec 15:59 redox_termios:0.1.1
drwxr-xr-x - matklad  4 Dec 15:59 remove_dir_all:0.5.1
drwxr-xr-x - matklad  4 Dec 15:59 rustc-demangle:0.1.9
drwxr-xr-x - matklad  4 Dec 15:59 ryu:0.2.7
drwxr-xr-x - matklad  4 Dec 15:59 semver-parser:0.7.0
drwxr-xr-x - matklad  4 Dec 15:59 semver:0.9.0
drwxr-xr-x - matklad  4 Dec 15:59 serde:1.0.80
drwxr-xr-x - matklad  4 Dec 15:59 serde_derive:1.0.80
drwxr-xr-x - matklad  4 Dec 15:59 serde_json:1.0.33
drwxr-xr-x - matklad  4 Dec 15:59 strsim:0.7.0
drwxr-xr-x - matklad  4 Dec 15:59 syn:0.15.22
drwxr-xr-x - matklad  4 Dec 15:59 synstructure:0.10.1
drwxr-xr-x - matklad  4 Dec 15:59 tempdir:0.3.7
drwxr-xr-x - matklad  4 Dec 15:59 termion:1.5.1
drwxr-xr-x - matklad  4 Dec 15:59 textwrap:0.10.0
drwxr-xr-x - matklad  4 Dec 15:59 unicode-width:0.1.5
drwxr-xr-x - matklad  4 Dec 15:59 unicode-xid:0.1.0
drwxr-xr-x - matklad  4 Dec 15:59 vec_map:0.8.1
drwxr-xr-x - matklad  4 Dec 15:59 walkdir:0.1.8
drwxr-xr-x - matklad  4 Dec 15:59 winapi-build:0.1.1
drwxr-xr-x - matklad  4 Dec 15:59 winapi-i686-pc-windows-gnu:0.4.0
drwxr-xr-x - matklad  4 Dec 15:59 winapi-x86_64-pc-windows-gnu:0.4.0
drwxr-xr-x - matklad  4 Dec 15:59 winapi:0.2.8
drwxr-xr-x - matklad  4 Dec 15:59 winapi:0.3.6
```

</details>

The amount of bells & whistles with respect to filtering, fancy progress and error reporting which can be added here is infinite. The current impl just does the most basic stuff.